### PR TITLE
getEstimatedDuration method should always return duration in the same unit

### DIFF
--- a/Jenkins/Build.php
+++ b/Jenkins/Build.php
@@ -125,7 +125,7 @@ class Jenkins_Build
     //duration is not found we fallback to calcule it.
     if (property_exists($this->build, 'estimatedDuration'))
     {
-      return $this->build->estimatedDuration;
+      return $this->build->estimatedDuration / 1000;
     }
 
     $duration = null;


### PR DESCRIPTION
estimatedDuration was returning duration in seconds. i'ts not the case since SHA: 1ccaae727d29dd884a18f26b638f18fd9ba47669

It should not change if estimatedDuration cames from jenkins's api (which is in miliseconds).

if we want to get the original value if must pass via a parmater of the getEstimatedDuration method that indidates that return value must be in miliseconds.
