### PR TITLE
Removed utf8_decode() that was applied on the parameters' description : ...

### DIFF
--- a/Jenkins/Job.php
+++ b/Jenkins/Job.php
@@ -78,7 +78,7 @@ class Jenkins_Job
           ? $parameterDefinition->defaultParameterValue->value
           : null;
         $description = property_exists($parameterDefinition, 'description')
-          ? utf8_decode($parameterDefinition->description)
+          ? $parameterDefinition->description
           : null;
         $choices     = property_exists($parameterDefinition, 'choices')
           ? $parameterDefinition->choices


### PR DESCRIPTION
...we want those as UTF-8
