### PR TITLE
Check Jenkins response in getJob() and return false for 404s

### DIFF
--- a/Jenkins.php
+++ b/Jenkins.php
@@ -190,6 +190,12 @@ class Jenkins
     curl_setopt($curl, CURLOPT_RETURNTRANSFER, 1);
     $ret = curl_exec($curl);
 
+    $response_info = curl_getinfo( $curl );
+
+    if ( 200 != $response_info['http_code'] ) {
+      return false;
+    }
+
     if (curl_errno($curl))
     {
       throw new RuntimeException(sprintf('Error during getting information for job %s on %s', $jobName, $this->baseUrl));


### PR DESCRIPTION
Instead of throwing a `RuntimeException` about `json_decode`, return
false if the job doesn’t exist.

Fixes #26
