### PR TITLE
Fix params sending for job execution

### DIFF
--- a/README.md
+++ b/README.md
@@ -56,6 +56,17 @@ Launch a Job
     // bool(true) if successful or throws a RuntimeException
 ```
 
+Launch a Job with Parameters
+------------
+
+```php
+    $job = $jenkins->launchJob("clone-deploy",array(
+        'name'=> <param_name>, 'value'=> <param_value>
+        'name'=> <param2_name>, 'value'=> <param2_value>
+    );
+    var_dump($job);
+    // bool(true) if successful or throws a RuntimeException
+```
 
 List the jobs of a given view
 -----------------------------

--- a/README.md
+++ b/README.md
@@ -61,8 +61,9 @@ Launch a Job with Parameters
 
 ```php
     $job = $jenkins->launchJob("clone-deploy",array(
-        'name'=> <param_name>, 'value'=> <param_value>
-        'name'=> <param2_name>, 'value'=> <param2_value>
+            'name'=> <param_name>, 'value'=> <param_value>
+            'name'=> <param2_name>, 'value'=> <param2_value>
+        )
     );
     var_dump($job);
     // bool(true) if successful or throws a RuntimeException

--- a/src/Jenkins.php
+++ b/src/Jenkins.php
@@ -241,10 +241,15 @@ class Jenkins
      */
     public function launchJob($jobName, $parameters = array())
     {
-        if (0 === count($parameters)) {
-            $url = sprintf('%s/job/%s/build', $this->baseUrl, $jobName);
-        } else {
-            $url = sprintf('%s/job/%s/buildWithParameters', $this->baseUrl, $jobName);
+        $url = sprintf('%s/job/%s/build', $this->baseUrl, $jobName);
+
+        if ($parameters) {
+            $parameters = array(
+                'json' => json_encode(array(
+                        "parameter" => $parameters
+                    )
+                )
+            );
         }
 
         $curl = curl_init($url);
@@ -259,7 +264,6 @@ class Jenkins
         }
 
         curl_setopt($curl, \CURLOPT_HTTPHEADER, $headers);
-
         curl_exec($curl);
 
         $this->validateCurl($curl, sprintf('Error trying to launch job "%s" (%s)', $jobName, $url));


### PR DESCRIPTION
Hello, I've tried using this sdk for starting jobs with parameters but had to modify it to make it work properly. Every time i tried sending parameters they would not appear on jenkins. So I debugged a little and found out that the way the parameters were sent by the library was wrong. 
- First there is no need to use the /buildWithParameters url 
- Second it is needed to send all parameters inside an array like this on curl_postFields

```
array(
    'json' => json_encode(array(
        "parameter" => $parameters
    )
)

```
I don't know if an update from jenkins itself broke the integration or if the integration never worked properly. This is just the way I fixed it for me. There is probably a better way for mantaining compatibility. If someone propose it, I will be glad to implement.
