### PR TITLE
Fixing getJob for job names with spaces

### DIFF
--- a/src/Jenkins.php
+++ b/src/Jenkins.php
@@ -275,6 +275,8 @@ class Jenkins
      */
     public function getJob($jobName)
     {
+        // Encode the job name, otherwise Jenkins won't match spaces.
+        $jobName = rawurlencode($jobName);
         $url  = sprintf('%s/job/%s/api/json', $this->baseUrl, $jobName);
         $curl = curl_init($url);
 


### PR DESCRIPTION
Spaces in the job name has to be replaced with `%20` when requesting `job/%s/api/json`, otherwise the job isn't found.