### PR TITLE
Added Job::getSubJobs() to get subjobs

### DIFF
--- a/src/Jenkins/Job.php
+++ b/src/Jenkins/Job.php
@@ -41,6 +41,16 @@ class Job
         return $builds;
     }
 
+	/**
+	 * @return array
+	 */
+	public function getSubJobs()
+	{
+		if (!isset($this->job->jobs)) {
+			return [];
+		}
+		return $this->job->jobs;
+	}
 
     /**
      * @param int $buildId


### PR DESCRIPTION
Added Job::getSubJobs() to get subjobs. Subjobs are used in in multibranch pipelines and wihtout this commit there is no way to view this subjobs.