### PR TITLE
Fixed using full name for the Jobs

### DIFF
--- a/src/Jenkins/Job.php
+++ b/src/Jenkins/Job.php
@@ -58,7 +58,7 @@ class Job
      */
     public function getName()
     {
-        return $this->job->name;
+        return $this->job->fullName;
     }
 
     /**


### PR DESCRIPTION
And make sure multi-depth job names are correct.

For example;
A Github multi-branch job name contains slashes, like `Github/My-Project/master`. For the API this should be changed to `Github/job/My-Project/job/master`. Note the 'job' between each level.